### PR TITLE
fix(config): add missing Consul access token configuration

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -59,6 +59,7 @@ quarkus:
 consul:
   host: 192.168.1.90
   port: 8500
+  access-token: ${CONSUL_TOKEN}
   service:
     host: ${quarkus.application.name}
   health:


### PR DESCRIPTION
## Summary
- Agrega la configuración `access-token: ${CONSUL_TOKEN}` que faltaba en `application-prod.yml`
- Permite que el servicio se registre correctamente en Consul usando autenticación por token
- Sin este valor, el registro en Consul falla si el agente tiene ACL habilitado

## Test plan
- [ ] Verificar que la variable de entorno `CONSUL_TOKEN` esté definida en el entorno de producción
- [ ] Confirmar que el servicio se registra exitosamente en Consul al arrancar
- [ ] Revisar logs de inicio para ausencia de errores de autenticación con Consul